### PR TITLE
Update to DB class

### DIFF
--- a/DDO_Life_Tracker/Database/IncarnationDatabase.cs
+++ b/DDO_Life_Tracker/Database/IncarnationDatabase.cs
@@ -48,14 +48,6 @@ namespace DDO_Life_Tracker.Database
             return await Database.GetWithChildrenAsync<CharactersTable>(id, recursive: true);
         }
 
-        public async Task<CharactersTable> GetCharacterByName(string name)
-        {
-            await Init();
-            List<CharactersTable> allCharacters = await Database.GetAllWithChildrenAsync<CharactersTable>();
-
-            return allCharacters.FirstOrDefault(x => x.Name == name) ?? throw new Exception($"Character name {name} not found");
-        }
-
         public async Task<int> SaveCharacterAsync(CharactersTable character)
         {
             await Init();

--- a/DDO_Life_Tracker/Services/IncarnationDBService.cs
+++ b/DDO_Life_Tracker/Services/IncarnationDBService.cs
@@ -51,15 +51,17 @@ namespace DDO_Life_Tracker.Services
             }
         }
 
-        public async Task<Character> GetCharacterByName(string name)
+        public async Task<Character> GetCharacterByNameAsync(string name)
         {
             try
             {
-                _logger.LogDebug($"Getting character name {name}");
+                _logger.LogDebug($"Getting character name: {name}");
 
-                CharactersTable character =  await _database.GetCharacterByName(name);
+                List<CharactersTable> characters =  await _database.GetCharactersAsync();
+                CharactersTable found = characters.FirstOrDefault(x => x.Name == name) 
+                    ?? throw new Exception($"No character found");
 
-                return DataToModel(character);
+                return DataToModel(found);
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
Removed the get by name method for the characters table from the DB class and just had the corresponding method in the service call them all and select out the one matching name. This keeps the DB class with the basic four methods per table. Tried to figure out a way to use generics with the tables and maybe only a basic four functions using <T> but the dependency injection made it difficult. Couldn't use a singleton nor a generic type in the DI. Would have to use the concrete table types effectively creating three different connections to the DB, potentially causing (however unlikely) collisions.