### PR TITLE
Add charactorview to incarnation page

### DIFF
--- a/DDO_Life_Tracker/Database/IncarnationDatabase.cs
+++ b/DDO_Life_Tracker/Database/IncarnationDatabase.cs
@@ -24,9 +24,9 @@ namespace DDO_Life_Tracker.Database
 
             _database = new SQLiteAsyncConnection(DBConstants.DatabasePath, DBConstants.Flags);
 #if DEBUG
-            await _database.DropTableAsync<CharactersTable>();
-            await _database.DropTableAsync<IncarnationsTable>();
-            await _database.DropTableAsync<ClassesTable>();
+            //await _database.DropTableAsync<CharactersTable>();
+            //await _database.DropTableAsync<IncarnationsTable>();
+            //await _database.DropTableAsync<ClassesTable>();
 #endif
             await _database.CreateTableAsync<CharactersTable>();
             await _database.CreateTableAsync<IncarnationsTable>();

--- a/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml
+++ b/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml
@@ -24,30 +24,37 @@
             <toolkit:Expander>
                 <toolkit:Expander.Header>
                     <HorizontalStackLayout
-                                    HorizontalOptions="Fill">
+                                    HorizontalOptions="Center">
                         <controls:CharacterView ThisCharacter="{Binding CurrentCharacter}"
                                                 CharacterName="{Binding CurrentCharacter.Name}"
                                                 NumberOfLives="{Binding CurrentCharacter.NumberOfLives}"
                                                 CreateDate="{Binding CurrentCharacter.CreateDate}"/>
                     </HorizontalStackLayout>
                 </toolkit:Expander.Header>
-                <StackLayout BindableLayout.ItemsSource="{Binding CurrentCharacter.IncarnationHistory}"
-                                         Padding="10,0,0,0">
+                <VerticalStackLayout BindableLayout.ItemsSource="{Binding CurrentCharacter.IncarnationHistory}"
+                                         Padding="20,0,20,0">
                     <BindableLayout.ItemTemplate>
                         <DataTemplate x:DataType="models:Incarnation">
-                            <HorizontalStackLayout Spacing="10">
+                            <Grid ColumnDefinitions="10*,30*,60*"
+                                              ColumnSpacing="5">
                                 <Image Source="{Binding Race.IconImgFileName}"
-                                           Grid.Column="0"/>
+                                       Grid.Column="0"
+                                       VerticalOptions="Center"
+                                       HorizontalOptions="Start"/>
                                 <Label Grid.Column="1"
-                                           TextColor="AntiqueWhite"
-                                           Text="{Binding Race.Name}"/>
-                                <Label Grid.Column="3"
-                                           TextColor="AntiqueWhite"
-                                           Text="{Binding CurrentClass}"/>
-                            </HorizontalStackLayout>
+                                       VerticalOptions="Center"
+                                       HorizontalOptions="Start"                                      
+                                       TextColor="AntiqueWhite"
+                                       Text="{Binding Race.Name}"/>
+                                <Label Grid.Column="2"
+                                       TextColor="AntiqueWhite"
+                                       VerticalOptions="Center"
+                                       HorizontalOptions="End" 
+                                       Text="{Binding CurrentClass}"/>
+                            </Grid>
                         </DataTemplate>
                     </BindableLayout.ItemTemplate>
-                </StackLayout>
+                </VerticalStackLayout>
             </toolkit:Expander>
         </StackLayout>
         <Border Padding="10"

--- a/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml
+++ b/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml
@@ -32,11 +32,10 @@
                     </HorizontalStackLayout>
                 </toolkit:Expander.Header>
                 <StackLayout BindableLayout.ItemsSource="{Binding CurrentCharacter.IncarnationHistory}"
-                                         Padding="10,0,0,10">
+                                         Padding="10,0,0,0">
                     <BindableLayout.ItemTemplate>
                         <DataTemplate x:DataType="models:Incarnation">
-                            <HorizontalStackLayout Spacing="25"
-                                                Margin="0,4,0,0">
+                            <HorizontalStackLayout Spacing="10">
                                 <Image Source="{Binding Race.IconImgFileName}"
                                            Grid.Column="0"/>
                                 <Label Grid.Column="1"
@@ -122,6 +121,35 @@
                             Clicked="OnClickAddClass"
                             BackgroundColor="DarkGreen"/>
                 </HorizontalStackLayout>
+                <CollectionView ItemsSource="{Binding ClassesToAdd}"
+                                MinimumHeightRequest="20">
+                    <CollectionView.ItemsLayout>
+                        <LinearItemsLayout ItemSpacing="2"
+                                   Orientation="Vertical"/>
+                    </CollectionView.ItemsLayout>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:IClass">
+                            <Grid ColumnDefinitions="20*,20*,60*"
+                                  Padding="10,0,10,0">
+                                <Image Source="{Binding IconImgFileName}"
+                                       VerticalOptions="Center"
+                                       HorizontalOptions="Start"
+                                       HeightRequest="40"/>
+                                <Label VerticalOptions="Center"
+                                       HorizontalOptions="End"
+                                       FontSize="20"
+                                       FontAttributes="Bold"
+                                       Grid.Column="1"
+                                       Text="{Binding Level}"/>
+                                <Label VerticalOptions="Center"
+                                       HorizontalOptions="End"
+                                       FontSize="20"
+                                       Grid.Column="2"
+                                       Text="{Binding Name}"/>
+                            </Grid>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
             </VerticalStackLayout>
         </Border>
         <HorizontalStackLayout                
@@ -132,10 +160,12 @@
                 Clicked="OnClickAddIncarntaionToCharacter"
                 WidthRequest="150"
                 BackgroundColor="Goldenrod"/>
-            <Button Text="Save Character"
-                Clicked="OnClickSaveCharacter"
-                WidthRequest="150"
-                BackgroundColor="DarkGreen"/>
+            <Button Text="X"
+                    WidthRequest="50"
+                    Background="DarkRed"
+                    FontSize="16"
+                    FontAttributes="Bold"
+                    Command="{Binding ResetFormCommand}"/>
         </HorizontalStackLayout>
     </VerticalStackLayout>
 </ContentPage>

--- a/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml
+++ b/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml
@@ -7,6 +7,7 @@
              xmlns:viewmodel="clr-namespace:DDO_Life_Tracker.ViewModels"
              xmlns:models="clr-namespace:DDO_Life_Tracker.Models"
              x:DataType="viewmodel:AddIncarnationViewModel"
+             xmlns:controls="clr-namespace:DDO_Life_Tracker.Pages.Controls"
              BackgroundColor="Black">
     <ContentPage.Resources>
         <Style x:Key="InvalidEntryStyle" TargetType="Entry">
@@ -17,15 +18,42 @@
         </Style>
     </ContentPage.Resources>
     
-    <VerticalStackLayout
-        Spacing="10">
-        <Label 
-            Text="Add a new character life:"
-            VerticalOptions="Center" 
-            HorizontalOptions="Center"/>
+    <VerticalStackLayout Spacing="3"
+                         WidthRequest="400">
+        <StackLayout WidthRequest="400">
+            <toolkit:Expander>
+                <toolkit:Expander.Header>
+                    <HorizontalStackLayout
+                                    HorizontalOptions="Fill">
+                        <controls:CharacterView ThisCharacter="{Binding CurrentCharacter}"
+                                                CharacterName="{Binding CurrentCharacter.Name}"
+                                                NumberOfLives="{Binding CurrentCharacter.NumberOfLives}"
+                                                CreateDate="{Binding CurrentCharacter.CreateDate}"/>
+                    </HorizontalStackLayout>
+                </toolkit:Expander.Header>
+                <StackLayout BindableLayout.ItemsSource="{Binding CurrentCharacter.IncarnationHistory}"
+                                         Padding="10,0,0,10">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="models:Incarnation">
+                            <HorizontalStackLayout Spacing="25"
+                                                Margin="0,4,0,0">
+                                <Image Source="{Binding Race.IconImgFileName}"
+                                           Grid.Column="0"/>
+                                <Label Grid.Column="1"
+                                           TextColor="AntiqueWhite"
+                                           Text="{Binding Race.Name}"/>
+                                <Label Grid.Column="3"
+                                           TextColor="AntiqueWhite"
+                                           Text="{Binding CurrentClass}"/>
+                            </HorizontalStackLayout>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </StackLayout>
+            </toolkit:Expander>
+        </StackLayout>
         <Border Padding="10"
                 StrokeThickness="3.0"
-                HorizontalOptions="Center"
+                HorizontalOptions="Fill"
                 BackgroundColor="Goldenrod"
                 Stroke="DarkRed"
                 StrokeShape="RoundRectangle 10">
@@ -47,52 +75,67 @@
         </Border>
         <Border Padding="10"
                 StrokeThickness="3.0"
-                HorizontalOptions="Center"
+                HorizontalOptions="Fill"
                 BackgroundColor="Goldenrod"
                 Stroke="DarkRed"
                 StrokeShape="RoundRectangle 10">
-            <HorizontalStackLayout
-            HorizontalOptions="Center"
-            Spacing="30"
-            Background="Goldenrod">
-
-                <Picker ItemsSource="{Binding SelectableClasses}"
-                    ItemDisplayBinding="{Binding Value}"
-                    SelectedItem="{Binding SelectedClass}"
-                    WidthRequest="200"
-                    BackgroundColor="AntiqueWhite"/>
-                <Entry Keyboard="Numeric"
-                   WidthRequest="70"
-                   FontSize="15"
-                   HorizontalTextAlignment="Center"
-                   Text="{Binding ClassLevel}"
-                   x:Name="ClassLevel"
-                   Placeholder="Level"
-                   PlaceholderColor="Black"
-                   BackgroundColor="AntiqueWhite">
-                    <Entry.Behaviors>
-                        <toolkit:NumericValidationBehavior 
-                InvalidStyle="{StaticResource InvalidEntryStyle}"
-                ValidStyle="{StaticResource ValidEntryStyle}"
-                Flags="ValidateOnValueChanged"
-                MinimumValue="1"
-                MaximumValue="20"
-                MaximumDecimalPlaces="0" />
-                    </Entry.Behaviors>
-                </Entry>
-                <Button Text="+Add Class"
-                    WidthRequest="150"
-                    Clicked="OnClickAddClass"
-                    BackgroundColor="DarkGreen"/>
-            </HorizontalStackLayout>
+            <VerticalStackLayout Spacing="10">
+                <HorizontalStackLayout
+                HorizontalOptions="Center"
+                Spacing="30"
+                Background="Goldenrod">
+                    <Label Text="Select Class: "
+                       VerticalOptions="Center"
+                       HorizontalOptions="Center"
+                       FontSize="20"/>
+                    <Picker ItemsSource="{Binding SelectableClasses}"
+                        ItemDisplayBinding="{Binding Value}"
+                        SelectedItem="{Binding SelectedClass}"
+                        WidthRequest="200"
+                        BackgroundColor="AntiqueWhite"/>
+                </HorizontalStackLayout>
+                <HorizontalStackLayout                
+                HorizontalOptions="Center"
+                Spacing="30"
+                Background="Goldenrod">
+                    <Entry Keyboard="Numeric"
+                           WidthRequest="100"
+                           FontSize="15"
+                           HorizontalTextAlignment="Center"
+                           Text="{Binding ClassLevel}"
+                           x:Name="ClassLevel"
+                           Placeholder="Level"
+                           PlaceholderColor="Black"
+                           BackgroundColor="AntiqueWhite">
+                        <Entry.Behaviors>
+                            <toolkit:NumericValidationBehavior 
+                        InvalidStyle="{StaticResource InvalidEntryStyle}"
+                        ValidStyle="{StaticResource ValidEntryStyle}"
+                        Flags="ValidateOnValueChanged"
+                        MinimumValue="1"
+                        MaximumValue="20"
+                        MaximumDecimalPlaces="0" />
+                        </Entry.Behaviors>
+                    </Entry>
+                    <Button Text="+Add Class"
+                            WidthRequest="200"
+                            Clicked="OnClickAddClass"
+                            BackgroundColor="DarkGreen"/>
+                </HorizontalStackLayout>
+            </VerticalStackLayout>
         </Border>
-        <Button Text="Add character life"
-            Clicked="OnClickAddIncarntaionToCharacter"
-                WidthRequest="250"
-            BackgroundColor="Goldenrod"/>
-        <Button Text="Save Character"
-            Clicked="OnClickSaveCharacter"
-                WidthRequest="250"
-            BackgroundColor="DarkGreen"/>
+        <HorizontalStackLayout                
+                HorizontalOptions="Center"
+                Spacing="30"
+            Margin="0,10,0,0">
+            <Button Text="Add character life"
+                Clicked="OnClickAddIncarntaionToCharacter"
+                WidthRequest="150"
+                BackgroundColor="Goldenrod"/>
+            <Button Text="Save Character"
+                Clicked="OnClickSaveCharacter"
+                WidthRequest="150"
+                BackgroundColor="DarkGreen"/>
+        </HorizontalStackLayout>
     </VerticalStackLayout>
 </ContentPage>

--- a/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml.cs
+++ b/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml.cs
@@ -21,7 +21,7 @@ public partial class AddIncarnationPage : ContentPage
 	{
 		try
 		{
-			_viewModel.AddClassToList();
+			_viewModel.AddClass();
         }
 		catch (Exception ex)
 		{

--- a/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml.cs
+++ b/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml.cs
@@ -21,7 +21,7 @@ public partial class AddIncarnationPage : ContentPage
 	{
 		try
 		{
-			_viewModel.AddClassToIncarnation();
+			_viewModel.AddClassToList();
         }
 		catch (Exception ex)
 		{

--- a/DDO_Life_Tracker/Pages/Controls/CharacterView.xaml
+++ b/DDO_Life_Tracker/Pages/Controls/CharacterView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="DDO_Life_Tracker.Pages.Controls.CharacterView"
              x:Name="this"
-             HorizontalOptions="Fill">
+             MinimumWidthRequest="400">
 
     <Frame BindingContext="{x:Reference this}"
            BackgroundColor="Goldenrod"

--- a/DDO_Life_Tracker/Pages/Controls/CharacterView.xaml
+++ b/DDO_Life_Tracker/Pages/Controls/CharacterView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="DDO_Life_Tracker.Pages.Controls.CharacterView"
              x:Name="this"
-             MinimumWidthRequest="400">
+             HorizontalOptions="Fill">
 
     <Frame BindingContext="{x:Reference this}"
            BackgroundColor="Goldenrod"

--- a/DDO_Life_Tracker/Pages/Controls/CharacterView.xaml
+++ b/DDO_Life_Tracker/Pages/Controls/CharacterView.xaml
@@ -6,7 +6,7 @@
              MinimumWidthRequest="400">
 
     <Frame BindingContext="{x:Reference this}"
-           BackgroundColor="DarkGoldenrod"
+           BackgroundColor="Goldenrod"
            BorderColor="DarkRed">
         <Grid RowDefinitions="50*,50*"
               ColumnDefinitions="60*,30*,5*"

--- a/DDO_Life_Tracker/Pages/MainPage.xaml
+++ b/DDO_Life_Tracker/Pages/MainPage.xaml
@@ -47,52 +47,31 @@
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:Character">
-                    <StackLayout
+                    <HorizontalStackLayout
+                        HorizontalOptions="Fill"
                         WidthRequest="400">
-                        <toolkit:Expander>
-                            <toolkit:Expander.Header>
-                                <HorizontalStackLayout
-                                    HorizontalOptions="Fill">
-                                    <HorizontalStackLayout.GestureRecognizers>
-                                        <TapGestureRecognizer Tapped="OnFocusCharacter"
-                                                              CommandParameter="{Binding .}"/>
-                                        <TapGestureRecognizer Tapped="OnDoubleTapCharacter"
-                                                              NumberOfTapsRequired="2"
-                                                              CommandParameter="{Binding .}"/>
-                                    </HorizontalStackLayout.GestureRecognizers>
-                                    <controls:CharacterView ThisCharacter="{Binding .}"
-                                                            CharacterName="{Binding Name}"
-                                                            NumberOfLives="{Binding NumberOfLives}"
-                                                            CreateDate="{Binding CreateDate}"/>
-                                </HorizontalStackLayout>
-                            </toolkit:Expander.Header>
-                            <VerticalStackLayout BindableLayout.ItemsSource="{Binding IncarnationHistory}"
-                                         Padding="20,0,20,0"
-                                                 Spacing="5">
-                                <BindableLayout.ItemTemplate>
-                                    <DataTemplate x:DataType="models:Incarnation">
-                                        <Grid ColumnDefinitions="10*,30*,60*"
-                                              ColumnSpacing="5">
-                                            <Image Source="{Binding Race.IconImgFileName}"
-                                                   Grid.Column="0"
-                                                   VerticalOptions="Center"
-                                                   HorizontalOptions="Start"/>
-                                            <Label Grid.Column="1"
-                                                   TextColor="AntiqueWhite"
-                                                   VerticalOptions="Center"
-                                                   HorizontalOptions="Start"
-                                                   Text="{Binding Race.Name}"/>
-                                            <Label Grid.Column="2"
-                                                   TextColor="AntiqueWhite"
-                                                   VerticalOptions="Center"
-                                                   HorizontalOptions="End"
-                                                   Text="{Binding CurrentClass}"/>
-                                        </Grid>
-                                    </DataTemplate>
-                                </BindableLayout.ItemTemplate>
-                            </VerticalStackLayout>
-                        </toolkit:Expander>
-                    </StackLayout>
+                        <HorizontalStackLayout.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnFocusCharacter"
+                                                  CommandParameter="{Binding .}"/>
+                            <TapGestureRecognizer Tapped="OnDoubleTapCharacter"
+                                                  NumberOfTapsRequired="2"
+                                                  CommandParameter="{Binding .}"/>
+                        </HorizontalStackLayout.GestureRecognizers>
+                        <HorizontalStackLayout.Behaviors>
+                            <toolkit:TouchBehavior
+                                DefaultAnimationDuration="250"
+                                DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
+                                PressedOpacity="0.9"
+                                PressedScale="0.95"
+                                LongPressDuration="750"
+                                LongPressCompleted="OnCharacterviewLongPress"
+                                LongPressCommandParameter="{Binding .}"/>
+                        </HorizontalStackLayout.Behaviors>
+                        <controls:CharacterView ThisCharacter="{Binding .}"
+                                                CharacterName="{Binding Name}"
+                                                NumberOfLives="{Binding NumberOfLives}"
+                                                CreateDate="{Binding CreateDate}"/>
+                    </HorizontalStackLayout>
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>

--- a/DDO_Life_Tracker/Pages/MainPage.xaml
+++ b/DDO_Life_Tracker/Pages/MainPage.xaml
@@ -39,7 +39,8 @@
                 Clicked="DeleteCharacter"/>
         <CollectionView Grid.Row="3"
                         Grid.Column="0"
-                        ItemsSource="{Binding Characters}">
+                        ItemsSource="{Binding Characters}"
+                        Margin="0,0,0,20">
             <CollectionView.ItemsLayout>
                 <LinearItemsLayout ItemSpacing="2"
                                    Orientation="Vertical"/>
@@ -65,24 +66,31 @@
                                                             CreateDate="{Binding CreateDate}"/>
                                 </HorizontalStackLayout>
                             </toolkit:Expander.Header>
-                            <StackLayout BindableLayout.ItemsSource="{Binding IncarnationHistory}"
-                                         Padding="10,0,0,10">
+                            <VerticalStackLayout BindableLayout.ItemsSource="{Binding IncarnationHistory}"
+                                         Padding="20,0,20,0"
+                                                 Spacing="5">
                                 <BindableLayout.ItemTemplate>
                                     <DataTemplate x:DataType="models:Incarnation">
-                                        <HorizontalStackLayout Spacing="25"
-                                                Margin="0,4,0,0">
+                                        <Grid ColumnDefinitions="10*,30*,60*"
+                                              ColumnSpacing="5">
                                             <Image Source="{Binding Race.IconImgFileName}"
-                                           Grid.Column="0"/>
+                                                   Grid.Column="0"
+                                                   VerticalOptions="Center"
+                                                   HorizontalOptions="Start"/>
                                             <Label Grid.Column="1"
-                                           TextColor="AntiqueWhite"
-                                           Text="{Binding Race.Name}"/>
-                                            <Label Grid.Column="3"
-                                           TextColor="AntiqueWhite"
-                                           Text="{Binding CurrentClass}"/>
-                                        </HorizontalStackLayout>
+                                                   TextColor="AntiqueWhite"
+                                                   VerticalOptions="Center"
+                                                   HorizontalOptions="Start"
+                                                   Text="{Binding Race.Name}"/>
+                                            <Label Grid.Column="2"
+                                                   TextColor="AntiqueWhite"
+                                                   VerticalOptions="Center"
+                                                   HorizontalOptions="End"
+                                                   Text="{Binding CurrentClass}"/>
+                                        </Grid>
                                     </DataTemplate>
                                 </BindableLayout.ItemTemplate>
-                            </StackLayout>
+                            </VerticalStackLayout>
                         </toolkit:Expander>
                     </StackLayout>
                 </DataTemplate>

--- a/DDO_Life_Tracker/Pages/MainPage.xaml.cs
+++ b/DDO_Life_Tracker/Pages/MainPage.xaml.cs
@@ -60,12 +60,25 @@ namespace DDO_Life_Tracker
             }
         }
 
-        private void OnDoubleTapCharacter(object sender, TappedEventArgs e)
+        private async void OnDoubleTapCharacter(object sender, TappedEventArgs e)
         {
             if (e.Parameter?.GetType() == typeof(Character))
             {
                 _focusedCharacter = (Character)e.Parameter;
             }
+
+            await _viewModel.GoToAddIncarnationPage(_focusedCharacter);
         }
+
+        private void OnCharacterviewLongPress(object sender, CommunityToolkit.Maui.Core.LongPressCompletedEventArgs e)
+        {
+            if (e.LongPressCommandParameter?.GetType() == typeof(Character))
+            {
+                _focusedCharacter = (Character)e.LongPressCommandParameter;
+            }
+
+            DeleteCharacter(sender, e);
+        }
+
     }
 }

--- a/DDO_Life_Tracker/ViewModels/AddIncarnationViewModel.cs
+++ b/DDO_Life_Tracker/ViewModels/AddIncarnationViewModel.cs
@@ -9,7 +9,9 @@ namespace DDO_Life_Tracker.ViewModels
     [QueryProperty("CurrentCharacter", "CurrentCharacter")]
     public partial class AddIncarnationViewModel : ObservableObject
     {
-        public Character CurrentCharacter { get; set; }
+        // QueryProperty
+        [ObservableProperty]
+        private Character _currentCharacter;
 
         [ObservableProperty]
         private List<KeyValuePair<int, string>> _selectableClasses;
@@ -51,7 +53,7 @@ namespace DDO_Life_Tracker.ViewModels
             else
             {
                 // catch if AddIncarnation btn clicked before adding 2nd+ class
-                // does rely on selector being cleared once class added
+                // does rely on selector being cleared once class added to prevent duplicates
                 if (SelectedClass.Key != default)
                 {
                     AddClassToIncarnation();

--- a/DDO_Life_Tracker/ViewModels/AddIncarnationViewModel.cs
+++ b/DDO_Life_Tracker/ViewModels/AddIncarnationViewModel.cs
@@ -47,7 +47,7 @@ namespace DDO_Life_Tracker.ViewModels
         {
             if (NewIncarnation == default)
             {
-                AddClassToList();
+                AddClass();
 
                 if(NewIncarnation == default)
                 {
@@ -60,7 +60,7 @@ namespace DDO_Life_Tracker.ViewModels
                 // does rely on selector being cleared once class added to prevent duplicates
                 if (SelectedClass.Key != default)
                 {
-                    AddClassToList();
+                    AddClass();
                 }
             }
 
@@ -76,7 +76,7 @@ namespace DDO_Life_Tracker.ViewModels
             _logger.LogInformation($"Character {CurrentCharacter.Name} saved with {CurrentCharacter.NumberOfLives} incarnations");
         }
 
-        public void AddClassToList()
+        public void AddClass()
         {
             IClass newClass = Definitions.IdToDDOClass(SelectedClass.Key);
             if (int.TryParse(ClassLevel, out int lvl))

--- a/DDO_Life_Tracker/ViewModels/MainViewModel.cs
+++ b/DDO_Life_Tracker/ViewModels/MainViewModel.cs
@@ -48,10 +48,10 @@ namespace DDO_Life_Tracker.ViewModels
             LoadingSpinnerActive = false;
         }
 
-        [RelayCommand]
-        public async Task GoToAddIncarnationPage()
+        public async Task GoToAddIncarnationPage(Character selectedCharacter)
         {
-            await Shell.Current.GoToAsync(nameof(AddIncarnationPage), true);
+            Dictionary<string, object> paramData = new Dictionary<string, object> { { "CurrentCharacter", selectedCharacter } };
+            await Shell.Current.GoToAsync(nameof(AddIncarnationPage), true, paramData);
         }
 
         [RelayCommand]


### PR DESCRIPTION
Character view added to incarnation page. Also added a list to display classes are part of a multiclass character. Adds incrementally to the new incarnation under the hood, but doesn't save to character until the add incarnation button click. This allows for the class validations in the IClass and Incarnation to bubble up to UI. Added a reset button to clear selections.  Lot of back and for on the main page got wrapped into this too. Ultimately the Community toolkit Expander didn't place nice being inside a CollectionView. Instead it will be just the custom Characterviews that can now be double clicked to be taken to the add incarnation page to add more classes. Probably should rename that page as it may become the "main" page for viewing a character details.
