### PR TITLE
Delete Class from existing Incarnation

### DIFF
--- a/DDO_Life_Tracker/Models/Incarnation.cs
+++ b/DDO_Life_Tracker/Models/Incarnation.cs
@@ -1,7 +1,9 @@
 ﻿
+using DDO_Life_Tracker.Services;
+
 namespace DDO_Life_Tracker.Models
 {
-    public class Incarnation : IIncarnation
+    public class Incarnation : IIncarnation, ICloneable
     {
         public int Id { get; set; }
         public int CharacterId { get; set; }
@@ -92,6 +94,22 @@ namespace DDO_Life_Tracker.Models
         public void IncrementClassLevel(string classNameToIncrement)
         {
             _currentClassDefinitions[classNameToIncrement].Level++;
+        }
+
+        public object Clone()
+        {
+            IRace copiedRace = Definitions.IdToDDORace(Race.Id);
+            List<IClass> copiedClasses = new List<IClass>();
+            foreach (IClass item in CurrentClassDefinitions)
+            {
+                IClass copy = Definitions.IdToDDOClass(item.ClassId);
+                copy.IncarnationId = item.IncarnationId;
+                copy.Level = item.Level;
+                copy.Id = item.Id;
+                copiedClasses.Add(copy);
+            }
+
+            return new Incarnation(CharacterId, copiedRace, copiedClasses, Id);
         }
     }
 }

--- a/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml
+++ b/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml
@@ -153,26 +153,43 @@
                         </CollectionView.ItemsLayout>
                         <CollectionView.ItemTemplate>
                             <DataTemplate x:DataType="models:IClass">
-                                <Grid ColumnDefinitions="20*,20*,60*"
-                                      Padding="10,0,10,0">
+                                <Grid ColumnDefinitions="10*,20*,20*,60*"
+                                      Padding="0,0,0,0">
                                     <Grid.GestureRecognizers>
                                         <TapGestureRecognizer Tapped="OnClickEditClass"
                                                               CommandParameter="{Binding .}"/>
                                     </Grid.GestureRecognizers>
+                                    <Border StrokeShape="RoundRectangle 80"
+                                            StrokeThickness="0"
+                                            WidthRequest="30"
+                                            HeightRequest="30"
+                                            HorizontalOptions="Start"
+                                            VerticalOptions="Center"
+                                            BackgroundColor="DarkRed">
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer Tapped="OnClickDeleteClass"
+                                                                      CommandParameter="{Binding .}"/>
+                                        </Border.GestureRecognizers>
+                                        <Label Text="X"
+                                               VerticalOptions="Center"
+                                               HorizontalOptions="Center"
+                                               TextColor="AntiqueWhite"/>
+                                    </Border>
                                     <Image Source="{Binding IconImgFileName}"
                                            VerticalOptions="Center"
-                                           HorizontalOptions="Start"
-                                           HeightRequest="40"/>
+                                           HorizontalOptions="Center"
+                                           HeightRequest="40"
+                                           Grid.Column="1"/>
                                     <Label VerticalOptions="Center"
-                                           HorizontalOptions="End"
+                                           HorizontalOptions="Center"
                                            FontSize="20"
                                            FontAttributes="Bold"
-                                           Grid.Column="1"
+                                           Grid.Column="2"
                                            Text="{Binding Level}"/>
                                     <Label VerticalOptions="Center"
                                            HorizontalOptions="End"
                                            FontSize="20"
-                                           Grid.Column="2"
+                                           Grid.Column="3"
                                            Text="{Binding Name}"/>
                                 </Grid>
                             </DataTemplate>

--- a/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml
+++ b/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml
@@ -168,7 +168,7 @@
                                             BackgroundColor="DarkRed">
                                         <Border.GestureRecognizers>
                                             <TapGestureRecognizer Tapped="OnClickDeleteClass"
-                                                                      CommandParameter="{Binding .}"/>
+                                                                  CommandParameter="{Binding .}"/>
                                         </Border.GestureRecognizers>
                                         <Label Text="X"
                                                VerticalOptions="Center"

--- a/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml.cs
+++ b/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml.cs
@@ -22,7 +22,7 @@ public partial class AddIncarnationPage : ContentPage
 	{
 		try
 		{
-			_viewModel.ClassButtonClick();
+			_viewModel.ClassButtonHandler();
         }
 		catch (Exception ex)
 		{
@@ -35,7 +35,7 @@ public partial class AddIncarnationPage : ContentPage
 	{
 		try
 		{
-			await _viewModel.IncarnationButtonClick();
+			await _viewModel.IncarnationButtonHandler();
             _ = Toast.Make("Character updated.", CommunityToolkit.Maui.Core.ToastDuration.Short, 12).Show();
         }
         catch (Exception ex)
@@ -97,7 +97,7 @@ public partial class AddIncarnationPage : ContentPage
 		{
             if (e.Parameter != default)
             {
-                _viewModel.DeleteClassClick((IClass)e.Parameter);
+                _viewModel.DeleteClassButtonHandler((IClass)e.Parameter);
             }
         }
 		catch(Exception ex) 

--- a/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml.cs
+++ b/DDO_Life_Tracker/Pages/AddIncarnationPage.xaml.cs
@@ -91,6 +91,22 @@ public partial class AddIncarnationPage : ContentPage
         }
     }
 
+	private async void OnClickDeleteClass(object sender, TappedEventArgs e)
+	{
+		try
+		{
+            if (e.Parameter != default)
+            {
+                _viewModel.DeleteClassClick((IClass)e.Parameter);
+            }
+        }
+		catch(Exception ex) 
+		{
+            _logger.LogError($"Error deleting class from list to edit: {ex}");
+            await DisplayAlert("Error", $"Unable to delete class: {ex.Message}", "Ok");
+        }
+	}
+
 	private async void OnClickDeleteCharacter(object sender, EventArgs e)
 	{
 		try

--- a/DDO_Life_Tracker/ViewModels/AddIncarnationViewModel.cs
+++ b/DDO_Life_Tracker/ViewModels/AddIncarnationViewModel.cs
@@ -56,32 +56,35 @@ namespace DDO_Life_Tracker.ViewModels
             SelectableRaces = Definitions.AllDdoRacesFormatted.ToList();
         }
 
-        public void ClassButtonClick()
+        public void ClassButtonHandler()
         {
             if(ClassBtnText == ADD_CLASS_BTN_TEXT)
             {
                 AddClass();
-            } else
+            } 
+            else
             {
                 UpdateClass();
             }
         }
 
-        public async Task IncarnationButtonClick()
+        public async Task IncarnationButtonHandler()
         {
             if(IncarnationBtnText == ADD_INCARNATION_BTN_TEXT)
             {
                 await AddIncarnationToCharacter();
-            } else
+            } 
+            else
             {
                 await UpdateIncarnation();
             }
         }
 
-        public void DeleteClassClick(IClass classToDelete)
+        public void DeleteClassButtonHandler(IClass classToDelete)
         {
             _classBeingEdited = classToDelete;
             RemoveClassFromIncarnation();
+            ResetClassEditor();
         }
 
         public async Task AddIncarnationToCharacter()
@@ -231,6 +234,7 @@ namespace DDO_Life_Tracker.ViewModels
         {
             ActiveIncarnation = default;
             IncarnationBtnText = ADD_INCARNATION_BTN_TEXT;
+            ClassesToAdd = new ObservableCollection<IClass>();
             ResetRaceEditor();
             ResetClassEditor();
         }
@@ -240,7 +244,6 @@ namespace DDO_Life_Tracker.ViewModels
             _classBeingEdited = default;
             SelectedClass = default;
             ClassLevel = string.Empty;
-            ClassesToAdd = new ObservableCollection<IClass>();
             ClassBtnText = ADD_CLASS_BTN_TEXT;
         }
 

--- a/DDO_Life_Tracker/ViewModels/AddIncarnationViewModel.cs
+++ b/DDO_Life_Tracker/ViewModels/AddIncarnationViewModel.cs
@@ -78,6 +78,12 @@ namespace DDO_Life_Tracker.ViewModels
             }
         }
 
+        public void DeleteClassClick(IClass classToDelete)
+        {
+            _classBeingEdited = classToDelete;
+            RemoveClassFromIncarnation();
+        }
+
         public async Task AddIncarnationToCharacter()
         {
             if (ActiveIncarnation == default)
@@ -145,7 +151,7 @@ namespace DDO_Life_Tracker.ViewModels
         {
             ResetClassEditor();
             ResetRaceEditor();
-            ActiveIncarnation = incarnation;
+            ActiveIncarnation = (Incarnation)incarnation.Clone();
             ClassesToAdd = ActiveIncarnation.CurrentClassDefinitions.ToObservableCollection();
             SelectedRace = SelectableRaces.First(r => r.Key == ActiveIncarnation.Race.Id);
             IncarnationBtnText = UPDATE_INCARNATION_BTN_TEXT;


### PR DESCRIPTION
Added button and functionality to delete a class from an existing incarnation after selecting. The 'button' had to be a border wrapped around a label with touch gestures. Apparently buttons in Windows have a minimum size and/or padding so there were formatting discrepancies.  Implemented ICloneable in Incarnation class so edits are made to a clone and easily discarded. 