### PR TITLE
Bug fix for orphaned records. 

### DIFF
--- a/DDO_Life_Tracker/Database/IncarnationDatabase.cs
+++ b/DDO_Life_Tracker/Database/IncarnationDatabase.cs
@@ -97,10 +97,10 @@ namespace DDO_Life_Tracker.Database
             return incarnation.Id;
         }
 
-        public async Task<int> DeleteIncarnationAsync(IncarnationsTable incarnation)
+        public async Task DeleteIncarnationAsync(IncarnationsTable incarnation)
         {
             await Init();
-            return await _database.DeleteAsync(incarnation);
+            await _database.DeleteAsync(incarnation, recursive: true);
         }
         #endregion
 
@@ -126,10 +126,10 @@ namespace DDO_Life_Tracker.Database
             return classItem.Id;
         }
 
-        public async Task<int> DeleteClassAsync(ClassesTable classItem)
+        public async Task DeleteClassAsync(ClassesTable classItem)
         {
             await Init();
-            return await _database.DeleteAsync(classItem);
+            await _database.DeleteAsync(classItem, recursive: true);
         }
         #endregion
     }

--- a/DDO_Life_Tracker/Database/Tables/ClassesTable.cs
+++ b/DDO_Life_Tracker/Database/Tables/ClassesTable.cs
@@ -19,7 +19,7 @@ namespace DDO_Life_Tracker.Database.Tables
         public int ClassId { get; set; }
         [NotNull]
         public int Level { get; set; }
-        [ManyToOne]
+        [ManyToOne(CascadeOperations = CascadeOperation.All)]
         public IncarnationsTable IncarnationsTable { get; set; }
     }
 }

--- a/DDO_Life_Tracker/Database/Tables/IncarnationsTable.cs
+++ b/DDO_Life_Tracker/Database/Tables/IncarnationsTable.cs
@@ -17,7 +17,7 @@ namespace DDO_Life_Tracker.Database.Tables
         public int RaceId { get; set; }
         [OneToMany(CascadeOperations = CascadeOperation.All)]
         public List<ClassesTable> Classes { get; set; }
-        [ManyToOne]
+        [ManyToOne(CascadeOperations = CascadeOperation.All)]
         public CharactersTable CharactersTable { get; set; }
     }
 }


### PR DESCRIPTION
Realized I had not set the recursive param on the DeleteIncarnations call so classes were being orphaned that way. Other issue was editing existing classes, the old was removed and new added but the PK Id and the IncarnationId of the existing class was not passed to the 'new' one, so the ORM thought it was a new record and abandoned old. Deleting a class entirely required a new class field to track the classes deleted since we're working with a cloned obj and potentially discarding changes. Part of that meant having the UpdateClass method add the new class itself rather than relying on the default AddClass as handling the transfer of Ids was too fragile.